### PR TITLE
Fixed: Bug TRAN-227

### DIFF
--- a/backend/services/src/analytics-api/analytics.api.service.ts
+++ b/backend/services/src/analytics-api/analytics.api.service.ts
@@ -22,6 +22,7 @@ export class AnalyticsService {
 			const queryBuilder = this.entityManager.createQueryBuilder()
 				.select('sector, COUNT("actionId") as count, MAX(action.updatedTime) as "latestTime"')
 				.from(ActionEntity, 'action')
+				.where('sector IS NOT NULL')
 				.groupBy('sector')
 				.orderBy('MAX(action.updatedTime)', 'DESC');
 
@@ -56,6 +57,7 @@ export class AnalyticsService {
 			const queryBuilder = this.entityManager.createQueryBuilder()
 				.select('sector, COUNT("projectId") as count, MAX(project.updatedTime) as "latestTime"')
 				.from(ProjectEntity, 'project')
+				.where('sector IS NOT NULL')
 				.groupBy('sector')
 				.orderBy('MAX(project.updatedTime)', 'DESC');
 


### PR DESCRIPTION
**Issue**: “No Sector Attached” is displayed in the graph when parent is removed from an activity. This is because the Sector is migrated from the parent action. is now Fixed.

https://xeptagon.atlassian.net/browse/TRAN-227

<img width="694" height="521" alt="image" src="https://github.com/user-attachments/assets/f1a80a7c-58fc-4001-a241-a5db5d4a0f8f" />

is now Fixed to
<img width="678" height="516" alt="image" src="https://github.com/user-attachments/assets/6cf6cf6e-512f-4d03-99fc-2d380ed2af16" />
