### PR TITLE
TRAN-252 & Fix on TRAN-246

### DIFF
--- a/web/src/Pages/Actions/ActionForm/actionForm.tsx
+++ b/web/src/Pages/Actions/ActionForm/actionForm.tsx
@@ -1176,9 +1176,7 @@ const actionForm: React.FC<FormLoadProps> = ({ method }) => {
                     </Button>
                   )}
                 </Col>
-                <Col span={20}>
-                  <InfoKpi />
-                </Col>
+                <Col span={20}>{!isView && <InfoKpi />}</Col>
               </Row>
             </div>
             {method !== 'create' && (

--- a/web/src/Pages/Dashboard/dashboard.tsx
+++ b/web/src/Pages/Dashboard/dashboard.tsx
@@ -216,8 +216,12 @@ const Dashboard = () => {
         chartId: 4,
         chartTitle: t('financeChartTitle'),
         chartDescription: t('financeChartDescription'),
-        categories: ['Support Received', 'Support Needed'],
-        values: [financeChartData.stats.supportReceived, financeChartData.stats.supportNeeded],
+        categories: ['Support Received', 'Support Needs'],
+
+        values: [
+          financeChartData.stats.supportReceived,
+          financeChartData.stats.supportNeeded - financeChartData.stats.supportReceived,
+        ],
         lastUpdatedTime: financeChartData.lastUpdate,
       });
     } catch (error: any) {

--- a/web/src/Pages/Programmes/ProgrammeForm/programmeForm.tsx
+++ b/web/src/Pages/Programmes/ProgrammeForm/programmeForm.tsx
@@ -1341,9 +1341,7 @@ const ProgrammeForm: React.FC<FormLoadProps> = ({ method }) => {
                     </Button>
                   )}
                 </Col>
-                <Col span={20}>
-                  <InfoKpi />
-                </Col>
+                <Col span={20}>{!isView && <InfoKpi />}</Col>
               </Row>
             </div>
             {method !== 'create' && (

--- a/web/src/Pages/Projects/ProjectForm/projectForm.tsx
+++ b/web/src/Pages/Projects/ProjectForm/projectForm.tsx
@@ -1355,9 +1355,7 @@ const ProjectForm: React.FC<FormLoadProps> = ({ method }) => {
                     </Button>
                   )}
                 </Col>
-                <Col span={20}>
-                  <InfoKpi />
-                </Col>
+                <Col span={20}>{!isView && <InfoKpi />}</Col>
               </Row>
               <Row gutter={gutterSize}>
                 <Col span={24}>


### PR DESCRIPTION
# TRAN-252 & Fix on TRAN-246
- https://xeptagon.atlassian.net/browse/TRAN-252
- https://xeptagon.atlassian.net/browse/TRAN-246

## [TRAN-252 | Updating Dashboard Charts for Support](https://github.com/xeptagondev/carbon-transparency/commit/e31870cc4982bf7afa811c5ea81f080dfc6ff7fe)
- Updated the logic for the `Activities Supported` statistic.
- Updated the Displaying Logic for the `Financing for Activities` Statistic.

## [TRAN-246 | Fix in Add info icon below KPIs](https://github.com/xeptagondev/carbon-transparency/commit/e98138fdc0604d64c6e67a342c73ba83b391a324)
- Removed the info message `InfoKpi` when just viewing an **Action**, **Programme** or **Project**.